### PR TITLE
add: DishCardの直書きdataをWebAPIに置きました(超簡易)

### DIFF
--- a/pages/api/getDishData.ts
+++ b/pages/api/getDishData.ts
@@ -2,23 +2,11 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Nutrition } from "globalType";
 
-type dishData = {
-  morning: [
-    { title: string; nutrition: object },
-    { title: string; nutrition: object },
-    { title: string; nutrition: object }
-  ];
-  lunch: [
-    { title: string; nutrition: object },
-    { title: string; nutrition: object }
-  ];
-  dinner: [
-    { title: string; nutrition: object },
-    { title: string; nutrition: object },
-    { title: string; nutrition: object }
-  ];
+type DishData = {
+  morning: { title: string; nutrition: Nutrition }[];
+  lunch: { title: string; nutrition: Nutrition }[];
+  dinner: { title: string; nutrition: Nutrition }[];
 };
-
 const protNutrition: Nutrition = {
   biotin: 2.7,
   ca: 5,
@@ -54,7 +42,7 @@ const protNutrition: Nutrition = {
   vitK: 1,
   zn: 0.1,
 };
-const dish: dishData = {
+const dish: DishData = {
   morning: [
     {
       title: "ご飯",
@@ -97,7 +85,7 @@ const dish: dishData = {
 
 export default function handler(
   req: NextApiRequest,
-  res: NextApiResponse<dishData>
+  res: NextApiResponse<DishData>
 ) {
   res.status(200).json(dish);
 }


### PR DESCRIPTION
# Summary
DishCardのDOMに直書きしている朝食~夕食、及び料理名や栄養価を返すAPIを作成しました。

# Detail & Points
オブジェクト(1層目)で返します。
morning, lunch, dinnerでオブジェクト(2層目)を持ち、それぞれが配列(3層目)として料理単品のデータをオブジェクト(4層目)で持ちます。
pages/indexでfetch→responseを確認済みです。

# Capture
