### PR TITLE
add: 8桁の日付を判別して食事データを返すAPIを作成

### DIFF
--- a/pages/api/dish/[date].ts
+++ b/pages/api/dish/[date].ts
@@ -87,9 +87,14 @@ const dish: DishData = {
     },
   ],
 };
-const validateDate = (text: string): boolean => {
-  const isExistenceDate = dayjs(text, "YYYYMMDD").format("YYYYMMDD") === text;
-  return isExistenceDate;
+const isExistDate = (text: string): boolean => {
+  const formatText = dayjs(text, "YYYYMMDD").format("YYYYMMDD");
+  return formatText === text;
+};
+const isBeforeToday = (text: string): boolean => {
+  const today = dayjs().format("YYYYMMDD");
+  const requestedDate = dayjs(text, "YYYYMMDD").format("YYYYMMDD");
+  return parseInt(requestedDate) <= parseInt(today);
 };
 const handler = (
   req: NextApiRequest,
@@ -99,13 +104,24 @@ const handler = (
   if (typeof date !== "string") {
     throw new Error("Parameter date must be string");
   }
-  if (validateDate(date)) {
-    res.status(200).json(dish);
-  } else {
-    res.status(400).send({
-      message: "Parameter date is not exist.",
-      statusCode: 400,
-    });
+  try {
+    if (isExistDate(date) && isBeforeToday(date)) {
+      res.status(200).json(dish);
+    } else {
+      throw new Error("Parameter date is not exist.");
+    }
+  } catch (e) {
+    if (e instanceof Error) {
+      res.status(400).send({
+        message: e.message,
+        statusCode: 400,
+      });
+    } else {
+      res.status(500).send({
+        message: "Internal server error",
+        statusCode: 400,
+      });
+    }
   }
 };
 export default handler;


### PR DESCRIPTION
# Summary
`/api/dish/YYYYMMDD` でdishDataを返します。
dishDataは固定値です。

# Detail & Points
- date値が日付として正しいかを判別するvalidationDate()を作りました。
- validation結果に応じて簡単にエラーハンドリングしてます。
- dishをどこかに置きたい
- `req.query.date`の型が `string | string[]`で、直に引数に渡すとエラーが出てしまうので解決策あれば聞きたいです。
<img width="405" alt="スクリーンショット 2022-03-02 12 56 29" src="https://user-images.githubusercontent.com/57176655/156292119-c400b11a-da95-4750-bcff-03580167c983.png">

# Capture
