### PR TITLE
fix apiスキーマとDB構造の修正

### DIFF
--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -9,3 +9,17 @@ export const isBeforeToday = (text: string): boolean => {
   const requestedDate = dayjs(text, "YYYYMMDD").format("YYYYMMDD");
   return parseInt(requestedDate) <= parseInt(today);
 };
+
+/**
+ * バイナリファイルをBase64エンコードする。
+ */
+export const arrayBufferToBinaryString = (arrayBuffer: ArrayBuffer) => {
+  let binaryString = "";
+  const bytes = new Uint8Array(arrayBuffer);
+  const len = bytes.byteLength;
+  for (let i = 0; i < len; i++) {
+    binaryString += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binaryString)
+}
+

--- a/src/shared/globalType.ts
+++ b/src/shared/globalType.ts
@@ -29,10 +29,10 @@ export type DishType = {
 };
 
 export type DishData = {
-  breakfast: DishType[];
-  lunch: DishType[];
-  dinner: DishType[];
-  snack: DishType[];
+  breakfast: Menu[];
+  lunch: Menu[];
+  dinner: Menu[];
+  snack: Menu[];
 };
 
 export type Meal = {


### PR DESCRIPTION
# Summary
createとreadのAPIスキーマを変更した。下記のDishData型になる
```ts
export type DishData = {
  breakfast: Menu[];
  lunch: Menu[];
  dinner: Menu[];
  snack: Menu[];
};

export type Menu = {
  id: number;
  recipeName?: string;
  imgUrl?: string;
  foodstuffs?: Foodstuff[];
  totalNutrition?: Nutrition;
  recipes?: RecipeType[];
  tips?: string;
  cost?: number;
  time?: number;
};

export type RecipeType = {
  id: number;
  content?: string;
};

export type Foodstuff = {
  id: number;
  name?: string;
  weight?: number;
  nutrition?: Nutrition;
};
```

# Detail & Points

# Capture
