### PR TITLE
menuCardプロパティ変更方法を修正

### DIFF
--- a/src/components/editMenu/EditMenuCard.tsx
+++ b/src/components/editMenu/EditMenuCard.tsx
@@ -27,6 +27,7 @@ type Props = {
   index: number;
   menu: Menu;
   removeMenuCard(id: number): void;
+  updateMenuCard(index: number, data: any, dataType: any): void;
 };
 
 export const EditMenuCard: React.VFC<Props> = (props) => {
@@ -40,7 +41,7 @@ export const EditMenuCard: React.VFC<Props> = (props) => {
   const [recipes, setRecipe] = useState<RecipeType[]>(props.menu.recipes ?? []);
   const onImageChange = (imageUrl: string) => {
     // ここでmenuに差し込むと良さそう
-    props.menu.imgUrl = imageUrl;
+    props.updateMenuCard(props.index, imageUrl, "imgUrl");
     console.log("imageuUrl", imageUrl);
   };
   let totalNutrition: Nutrition | undefined =
@@ -48,11 +49,9 @@ export const EditMenuCard: React.VFC<Props> = (props) => {
 
   const addFoodstuff = () => {
     addElement(foodstuffs, setFoodstuff);
-    props.menu.foodstuffs = foodstuffs;
   };
   const removeFoodstuff = (index: number) => {
     removeElemnt(foodstuffs, setFoodstuff, index);
-    props.menu.foodstuffs = foodstuffs;
   };
   const updateFoodstuff = (data: Foodstuff) => {
     let copyFoodstuffs = [...foodstuffs];
@@ -62,36 +61,47 @@ export const EditMenuCard: React.VFC<Props> = (props) => {
       }
     });
     setFoodstuff(copyFoodstuffs);
-    props.menu.foodstuffs = copyFoodstuffs;
-    props.menu.totalNutrition =
+    props.updateMenuCard(
+      props.index,
       calSumNutritionFromFoodstuff(copyFoodstuffs) ??
-      dummyMenu[0].totalNutrition;
+        dummyMenu[0].totalNutrition,
+      "totalNutrition"
+    );
   };
   const addRecipe = useCallback(
     (index: number) => {
       addElement(recipes, setRecipe, index);
-      props.menu.recipes = recipes;
     },
     [props.menu, recipes]
   );
   const removeRecipe = (index: number) => {
     removeElemnt(recipes, setRecipe, index);
-    props.menu.recipes = recipes;
   };
   const writeRecipe = (index: number, value: string) => {
     let copyRecipes = [...recipes];
     copyRecipes[index].content = value;
     setRecipe(copyRecipes);
-    props.menu.recipes = copyRecipes;
   };
 
   useEffect(() => {
-    if (props.menu.recipes?.length == 0) addRecipe(0);
+    if (!props.menu.recipes || props.menu.recipes?.length == 0) addRecipe(0);
     recipeNameRef.current.value = props.menu.recipeName ?? "";
     costRef.current.value = props.menu.cost?.toString() ?? "";
     timeRef.current.value = props.menu.time?.toString() ?? "";
     tipsRef.current.value = props.menu.tips ?? "";
   }, []);
+
+  useEffect(() => {
+    props.updateMenuCard(props.index, recipes, "recipes");
+  }, [recipes]);
+
+  useEffect(() => {
+    props.updateMenuCard(
+      props.index,
+      recipeNameRef?.current.value ?? "",
+      "recipeName"
+    );
+  }, [foodstuffs]);
 
   return (
     <div className="flex justify-center my-10 lg:mx-5 sm:mx-20 mx-10">
@@ -114,7 +124,11 @@ export const EditMenuCard: React.VFC<Props> = (props) => {
               placeholder="料理名を入力して下さい"
               aria-label="Full name"
               onBlur={() => {
-                props.menu.recipeName = recipeNameRef?.current.value ?? "";
+                props.updateMenuCard(
+                  props.index,
+                  recipeNameRef?.current.value ?? "",
+                  "recipeName"
+                );
               }}
             />
           </div>
@@ -177,7 +191,11 @@ export const EditMenuCard: React.VFC<Props> = (props) => {
               className="text-sm appearance-none bg-transparent border-none w-full text-gray-700 mr-3 py-1 px-2 leading-tight focus:outline-none"
               aria-label="Full name"
               onBlur={() => {
-                props.menu.tips = tipsRef?.current?.value ?? "";
+                props.updateMenuCard(
+                  props.index,
+                  tipsRef?.current.value ?? "",
+                  "tips"
+                );
               }}
             />
           </div>
@@ -195,7 +213,11 @@ export const EditMenuCard: React.VFC<Props> = (props) => {
                   type="number"
                   className="border text-sm w-10 ml-1 rounded text-right"
                   onBlur={() => {
-                    props.menu.time = Number(timeRef?.current?.value) ?? "";
+                    props.updateMenuCard(
+                      props.index,
+                      timeRef?.current.value ?? "",
+                      "time"
+                    );
                   }}
                 />{" "}
                 分
@@ -211,7 +233,11 @@ export const EditMenuCard: React.VFC<Props> = (props) => {
                   type="number"
                   className="border text-sm  w-10 ml-1 rounded text-right"
                   onBlur={() => {
-                    props.menu.cost = Number(costRef?.current?.value) ?? "";
+                    props.updateMenuCard(
+                      props.index,
+                      costRef?.current.value ?? "",
+                      "cost"
+                    );
                   }}
                 />{" "}
                 円

--- a/src/pages/[currentDate]/[whenMeal].tsx
+++ b/src/pages/[currentDate]/[whenMeal].tsx
@@ -43,6 +43,19 @@ const EditMenuPage: NextPage = () => {
   const removeMenuCard = (index: number) => {
     removeElemnt(menuCards, setMenuCards, index);
   };
+  const updateMenuCard = (index: number, data: any, dataType: any) => {
+    const copyMenuCard = [...menuCards];
+    if (dataType == "recipeName") copyMenuCard[index].recipeName = data;
+    if (dataType == "imgUrl") copyMenuCard[index].imgUrl = data;
+    if (dataType == "foodstuffs") copyMenuCard[index].foodstuffs = data;
+    if (dataType == "recipes") copyMenuCard[index].recipes = data;
+    if (dataType == "tips") copyMenuCard[index].tips = data;
+    if (dataType == "cost") copyMenuCard[index].cost = data;
+    if (dataType == "time") copyMenuCard[index].time = data;
+    if (dataType == "totalNutrition") copyMenuCard[index].totalNutrition = data;
+
+    setMenuCards(copyMenuCard);
+  };
 
   const handleOnSubmit = async () => {
     await axios
@@ -69,6 +82,10 @@ const EditMenuPage: NextPage = () => {
     }
   }, [data]);
 
+  useEffect(() => {
+    console.log(menuCards);
+  }, [menuCards]);
+
   return (
     <div>
       <Head>
@@ -92,6 +109,7 @@ const EditMenuPage: NextPage = () => {
               index={index}
               menu={menuCard}
               removeMenuCard={removeMenuCard}
+              updateMenuCard={updateMenuCard}
             />
           ))}
           <div className="flex justify-center my-5">


### PR DESCRIPTION
# Summary
menuCardを更新するupdateMenuCard()を定義

# Detail & Points
propsからstateを直接変更するのはタブーなので、updateMenuCard()を通して変更するようにしました。
useEffectでrecipes,foodstuffsの変更を検知し、updateMenuCard()を呼び出しています。
他にもrecipeNameやtimeなどもuseEffectでできると思っていましたが、useRefを使っているため、useEffectがinputタグのvalueの変更を検知しませんでした。なのでuseRefを使っているものはonBlur内でupdateMenuCard()を呼び出しています。

# Capture
